### PR TITLE
Fix wrongly ordered relationships

### DIFF
--- a/src/Http/Controllers/SortableController.php
+++ b/src/Http/Controllers/SortableController.php
@@ -80,7 +80,7 @@ class SortableController
                 foreach ($resourceIds as $i => $id) {
                     $_model = $relatedModelsCopy->firstWhere($relatedKeyName, $id);
                     $relatedModelsCopy = $relatedModelsCopy->forget($relatedModelsCopy->search($_model));
-                    $sortOrderNr = $sortedOrder[$i];
+                    $sortOrderNr = $i;
 
                     $_model->{$orderColumnName} = $sortOrderNr;
                     $_model->save();


### PR DESCRIPTION
I'm not sure if I should start an issue first or this PR- I'll go ahead with a PR to discuss this further. 

I'm using Laravel Sortable on a BelongsToMany Relationship and been receiving many reports that the sorting order isn't being consistent or working as expected. 

When I checked my database, I saw that the sort_order had been completely messed up, with multiple models receiving the same sort order number. See picture below.
<img width="78" alt="Screenshot 2022-05-11 at 13 38 45" src="https://user-images.githubusercontent.com/6080053/167852156-cf9b224b-3006-4c98-b368-3820e5a42052.png">

This means the logic on the lines below would not reorder all the models and keep these "duplicated" sort order numbers.  

The fix below is to essentially order according to the resource ids order (correct order as seen onscreen). Will that affect other parts of the system? I noticed a fixSortOrder method as well?

