### PR TITLE
Update README.md to reflect deprecation of calling static method on traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,15 @@ You can add your translations to `resources/lang/vendor/nova-sortable/` by creat
 This package overwrites the `indexQuery` of the Resource and if you still want to use it, you can do it as follows:
 
 ```php
+use HasSortableRows {
+    indexQuery as indexSortableQuery;
+}
+
 public static function indexQuery(NovaRequest $request, $query)
 {
   // Do whatever with the query
   // ie $query->withCount(['children', 'descendants', 'modules']);
-  return parent::indexQuery($request, HasSortableRows::indexQuery($request, $query));
+  return parent::indexQuery($request, static::indexSortableQuery($request, $query));
 }
 ```
 


### PR DESCRIPTION
Calling static method on traits has been deprecated in PHP 8.1 (See: https://www.php.net/manual/en/language.oop5.traits.php#language.oop5.traits.static).

Solution: Use an alias to import `HasSortableRows::indexQuery` and calling it statically.