### PR TITLE
Fix table header when row not selectable

### DIFF
--- a/resources/js/components/ResourceTableHeader.vue
+++ b/resources/js/components/ResourceTableHeader.vue
@@ -1,0 +1,86 @@
+<template>
+  <thead class="bg-gray-50 dark:bg-gray-800">
+    <tr>
+      <!-- Select Checkbox -->
+      <th
+        class="td-fit uppercase text-xxs text-gray-500 tracking-wide pl-5 pr-2 py-2"
+        :class="{
+          'border-r border-gray-200 dark:border-gray-600':
+            shouldShowColumnBorders,
+        }"
+        v-if="shouldShowCheckboxes || canSeeReorderButtons"
+      >
+        <span v-if="shouldShowCheckboxes" class="sr-only">{{ __('Selected Resources') }}</span>
+      </th>
+
+      <!-- Field Names -->
+      <th
+        v-for="(field, index) in fields"
+        :key="field.uniqueKey"
+        :class="{
+          [`text-${field.textAlign}`]: true,
+          'border-r border-gray-200 dark:border-gray-600':
+            shouldShowColumnBorders,
+          'px-6': index == 0 && !shouldShowCheckboxes && !canSeeReorderButtons,
+          'px-2': index != 0 || shouldShowCheckboxes || canSeeReorderButtons,
+          'whitespace-nowrap': !field.wrapping,
+        }"
+        class="uppercase text-gray-500 text-xxs tracking-wide py-2"
+      >
+        <SortableIcon
+          @sort="requestOrderByChange(field)"
+          @reset="resetOrderBy(field)"
+          :resource-name="resourceName"
+          :uri-key="field.sortableUriKey"
+          v-if="sortable && field.sortable"
+        >
+          {{ field.indexName }}
+        </SortableIcon>
+
+        <span v-else>{{ field.indexName }}</span>
+      </th>
+
+      <!-- View, Edit, and Delete -->
+      <th class="uppercase text-xxs tracking-wide px-2 py-2">
+        <span class="sr-only">{{ __('Controls') }}</span>
+      </th>
+    </tr>
+  </thead>
+</template>
+
+<script>
+import ReordersResources from '../mixins/ReordersResources'
+
+export default {
+  name: 'ResourceTableHeader',
+
+  mixins: [ReordersResources],
+
+  emits: ['order', 'reset-order-by'],
+
+  props: {
+    resourceName: String,
+    shouldShowColumnBorders: Boolean,
+    shouldShowCheckboxes: Boolean,
+    fields: {
+      type: [Object, Array],
+    },
+    sortable: Boolean,
+  },
+  methods: {
+    /**
+     * Broadcast that the ordering should be updated.
+     */
+    requestOrderByChange(field) {
+      this.$emit('order', field)
+    },
+
+    /**
+     * Broadcast that the ordering should be reset.
+     */
+    resetOrderBy(field) {
+      this.$emit('reset-order-by', field)
+    },
+  },
+}
+</script>

--- a/resources/js/entry.js
+++ b/resources/js/entry.js
@@ -1,9 +1,11 @@
 import ResourceTable from './components/ResourceTable';
+import ResourceTableHeader from './components/ResourceTableRow';
 import ResourceTableRow from './components/ResourceTableRow';
 import ReorderButtons from './components/ReorderButtons';
 
 Nova.booting((app, router, store) => {
   app.component('ResourceTable', require('./components/ResourceTable').default);
+  app.component('ResourceTableHeader', require('./components/ResourceTableHeader').default);
   app.component('ResourceTableRow', require('./components/ResourceTableRow').default);
   app.component('ReorderButtons', require('./components/ReorderButtons').default);
 });


### PR DESCRIPTION
Hi,
When checkboxes are not visible in table rows, the header is broken:
![image](https://user-images.githubusercontent.com/3834222/195912297-bf88b819-1994-491e-822f-5832028ff16d.png)

I couldn't test the fix myself because of peer dependencies. Fill free to edit the PR to build the sources.

Thank you!
Karel