### PR TITLE
[Fix] Update-order failed when scopes used

### DIFF
--- a/src/Http/Controllers/SortableController.php
+++ b/src/Http/Controllers/SortableController.php
@@ -4,7 +4,6 @@ namespace Outl1ne\NovaSortable\Http\Controllers;
 
 use Laravel\Nova\Nova;
 use Laravel\Nova\Http\Requests\NovaRequest;
-use Outl1ne\NovaSortable\Traits\HasSortableRows;
 
 class SortableController
 {
@@ -95,10 +94,11 @@ class SortableController
         if (empty($resourceClass)) return response()->json(['resourceName' => 'invalid'], 400);
 
         $modelClass = $resourceClass::$model;
+        $query = $modelClass::query();
         if (method_exists($modelClass, 'trashed')) {
-            $models = $modelClass::withTrashed()->findMany($resourceIds);
+            $models = $resourceClass::indexQuery($request, $query)->withTrashed()->findMany($resourceIds);
         } else {
-            $models = $modelClass::findMany($resourceIds);
+            $models = $resourceClass::indexQuery($request, $query)->findMany($resourceIds);
         }
         if ($models->count() !== sizeof($resourceIds)) return response()->json(['resourceIds' => 'invalid'], 400);
 


### PR DESCRIPTION
- Updated updateOrder method to use the indexQuery builder from the Nova resource of the sortable model, so the user's custom global scopes are also applied.