### PR TITLE
Declares indexQuery return type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=8.0",
     "spatie/eloquent-sortable": "^3.10.0|^4.0",
-    "laravel/nova": "^4.24.0",
+    "laravel/nova": "^4.27.12",
     "outl1ne/nova-translations-loader": "^5.0"
   },
   "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=8.0",
     "spatie/eloquent-sortable": "^3.10.0|^4.0",
-    "laravel/nova": "^4.27.12",
+    "laravel/nova": "^4.24.0",
     "outl1ne/nova-translations-loader": "^5.0"
   },
   "repositories": [

--- a/src/Traits/HasSortableRows.php
+++ b/src/Traits/HasSortableRows.php
@@ -2,6 +2,7 @@
 
 namespace Outl1ne\NovaSortable\Traits;
 
+use Illuminate\Database\Eloquent\Builder;
 use Spatie\EloquentSortable\SortableTrait;
 use Laravel\Nova\Http\Requests\LensRequest;
 use Laravel\Nova\Http\Requests\NovaRequest;
@@ -109,7 +110,7 @@ trait HasSortableRows
         return array_merge(parent::serializeForIndex($request, $fields), $sortabilityData);
     }
 
-    public static function indexQuery(NovaRequest $request, $query)
+    public static function indexQuery(NovaRequest $request, $query): Builder
     {
         $sortability = static::getSortability($request);
 


### PR DESCRIPTION
When I open Laravel Nova with the implemented package I get the following error: https://flareapp.io/share/q5Yze1Qm. This PR will fix the error.

The Resource class from which the indexQuery method will be overwritten in the HasSortableRows Trait contains the `: Builder` response type declaration. This PR implements this `: Builder` response type declaration within the HasSortableRows Trait.

This fixes the issue.

PS: I've also bumped the laravel/nova version to `^4.27.10`.