### PR TITLE
fix: Edit button on `ResourceTableRow` doesn't work with many-to-many resource

### DIFF
--- a/resources/js/components/ResourceTableRow.vue
+++ b/resources/js/components/ResourceTableRow.vue
@@ -363,6 +363,16 @@ export default {
     ...mapGetters(['currentUser']),
 
     updateURL() {
+      if (this.viaManyToMany) {
+        return this.$url(
+          `/resources/${this.viaResource}/${this.viaResourceId}/edit-attached/${this.resourceName}/${this.resource.id.value}`,
+          {
+            viaRelationship: this.viaRelationship,
+            viaPivotId: this.resource.id.pivotValue,
+          }
+        )
+      }
+ 
       return this.$url(
         `/resources/${this.resourceName}/${this.resource.id.value}/edit`,
         {


### PR DESCRIPTION
fixes #210